### PR TITLE
Override CD pre burnout

### DIFF
--- a/src/main/java/com/waterloorocketry/airbrakeplugin/AirbrakePluginSimulationListener.java
+++ b/src/main/java/com/waterloorocketry/airbrakeplugin/AirbrakePluginSimulationListener.java
@@ -75,7 +75,7 @@ public class AirbrakePluginSimulationListener extends AbstractSimulationListener
 		final double airbrakeExt = flightData.getLast(airbrakeExtDataType);
 		
 		// Override CD only during coast, and until velocity is too small for the drag tabulation to be accurate
-		if (burnout && !status.isApogeeReached() && velocity > 23.5) {
+		if (!status.isApogeeReached() && velocity > 23.5) {
 			double calculatedCd = TrajectoryPrediction.interpolate_cd(airbrakeExt, velocity, altitude);
 			forces.setCDaxial(calculatedCd);
 		}


### PR DESCRIPTION
I think this makes the cd more consistent throughout the flight

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/or-airbrake-plugin/8)
<!-- Reviewable:end -->
